### PR TITLE
feat: add user whitelist for ai-task issues (#5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,20 @@ GITHUB_REPO=your-username/your-repo
 GITHUB_USERNAME=your-username
 
 # ============================================================
+# User Whitelist (Optional - for public repos)
+# ============================================================
+
+# Comma-separated list of GitHub usernames allowed to create ai-task issues
+# Leave empty or unset to allow ALL users (default behavior)
+# When set, only issues from these users will be picked up
+# Example: ALLOWED_USERS=BuffMcBigHuge,contributor1,contributor2
+ALLOWED_USERS=
+
+# Note: Users not in the whitelist can still have their issues processed
+# if a whitelisted user adds the 'ai-approved' label to their issue.
+# This allows transferring/approving issues from the community.
+
+# ============================================================
 # Scheduler Configuration  
 # ============================================================
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ const configSchema = z.object({
         token: z.string().min(1, 'GITHUB_TOKEN is required'),
         repo: z.string().regex(/^[^/]+\/[^/]+$/, 'GITHUB_REPO must be in owner/repo format'),
         username: z.string().min(1, 'GITHUB_USERNAME is required'),
+        allowedUsers: z.array(z.string()).default([]),
     }),
 
     // Scheduler
@@ -92,6 +93,14 @@ function parseNumber(value: string | undefined, defaultValue: number): number {
 }
 
 /**
+ * Parse comma-separated string to array of trimmed strings
+ */
+function parseStringArray(value: string | undefined): string[] {
+    if (!value || value.trim() === '') return [];
+    return value.split(',').map(s => s.trim()).filter(s => s.length > 0);
+}
+
+/**
  * Load and validate configuration from environment
  */
 export function loadConfig(): Config {
@@ -100,6 +109,7 @@ export function loadConfig(): Config {
             token: process.env.GITHUB_TOKEN || '',
             repo: process.env.GITHUB_REPO || '',
             username: process.env.GITHUB_USERNAME || '',
+            allowedUsers: parseStringArray(process.env.ALLOWED_USERS),
         },
         scheduler: {
             pollIntervalMs: parseNumber(process.env.POLL_INTERVAL_MS, 300000),

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -11,6 +11,7 @@ export interface Issue {
     body: string;
     labels: string[];
     comments: Comment[];
+    author: string;
     createdAt: string;
     updatedAt: string;
 }
@@ -86,6 +87,7 @@ export class GitHubClient {
                         body: issue.body || '',
                         labels: issue.labels.map((l) => (typeof l === 'string' ? l : l.name || '')),
                         comments,
+                        author: issue.user?.login || 'unknown',
                         createdAt: issue.created_at,
                         updatedAt: issue.updated_at,
                     };

--- a/src/github/labels.ts
+++ b/src/github/labels.ts
@@ -10,6 +10,7 @@ export const Labels = {
     AI_BLOCKED: 'ai-blocked',
     AI_REVIEW_READY: 'ai-review-ready',
     AI_DEBUGGING: 'ai-debugging',
+    AI_APPROVED: 'ai-approved',
     PRIORITY_HIGH: 'ai-priority:high',
     PRIORITY_MEDIUM: 'ai-priority:medium',
     PRIORITY_LOW: 'ai-priority:low',
@@ -24,6 +25,7 @@ export const LabelColors = {
     [Labels.AI_BLOCKED]: '7057ff', // Purple
     [Labels.AI_REVIEW_READY]: '1d76db', // Blue
     [Labels.AI_DEBUGGING]: 'd93f0b', // Red/Orange
+    [Labels.AI_APPROVED]: '0e8a16', // Green (approved = trusted)
     [Labels.PRIORITY_HIGH]: 'b60205', // Red
     [Labels.PRIORITY_MEDIUM]: 'fbca04', // Yellow
     [Labels.PRIORITY_LOW]: '0052cc', // Blue
@@ -64,4 +66,22 @@ export function isReviewReady(issue: Issue): boolean {
  */
 export function needsDebugging(issue: Issue): boolean {
     return issue.labels.includes(Labels.AI_DEBUGGING);
+}
+
+export function isUserAllowed(issue: Issue, config: Config): boolean {
+    const allowedUsers = config.github.allowedUsers;
+    
+    if (allowedUsers.length === 0) {
+        return true;
+    }
+    
+    if (allowedUsers.includes(issue.author)) {
+        return true;
+    }
+    
+    if (issue.labels.includes(Labels.AI_APPROVED)) {
+        return true;
+    }
+    
+    return false;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import cron from 'node-cron';
 import process from 'node:process';
 import { loadConfig, Config } from './config.js';
 import { GitHubClient, Issue } from './github/client.js';
-import { Labels, isReadyForPickup, isBlocked } from './github/labels.js';
+import { Labels, isReadyForPickup, isBlocked, isUserAllowed } from './github/labels.js';
 import { TaskManager } from './tasks/manager.js';
 import { WorktreeManager } from './tasks/worktree.js';
 import { OpenCodeServerManager } from './tasks/opencode-server.js';
@@ -148,7 +148,7 @@ class GitHubTaskOrchestrator {
                 break;
             }
 
-            if (isReadyForPickup(issue)) {
+            if (isReadyForPickup(issue) && isUserAllowed(issue, this.config)) {
                 try {
                     await this.taskManager.startTask(issue);
                     logger.info({ issueNumber: issue.number, title: issue.title }, 'Started task');


### PR DESCRIPTION
## Summary

Adds an optional user whitelist feature to protect public repos from being barraged with `ai-task` issues.

## Changes

### Primary Feature: User Whitelist (`ALLOWED_USERS`)
- Add `ALLOWED_USERS` env var: comma-separated list of GitHub usernames
- When empty/unset: **all users allowed** (maintains backward compatibility)
- When set: only issues created by listed users are picked up

### Secondary Feature: Issue Transfer (`ai-approved` label)
- Add `ai-approved` label for whitelisted users to approve non-whitelisted issues
- Flow: Non-whitelisted user creates issue → Whitelisted user adds `ai-approved` label → Orchestrator picks it up
- This allows "transfer" of issues from community members without requiring them to be whitelisted

## Files Modified

| File | Changes |
|------|---------|
| `src/config.ts` | Added `github.allowedUsers: string[]` config and `parseStringArray` helper |
| `src/github/labels.ts` | Added `AI_APPROVED` label constant and `isUserAllowed()` function |
| `src/github/client.ts` | Added `author` field to Issue interface |
| `src/index.ts` | Integrated `isUserAllowed()` check in issue filtering |
| `.env.example` | Documented new `ALLOWED_USERS` option with examples |

## Usage

```bash
# Allow only specific users to create ai-task issues
ALLOWED_USERS=BuffMcBigHuge,contributor1,contributor2

# Or leave empty to allow all users (default)
ALLOWED_USERS=
```

## Testing

- [x] TypeScript build passes
- [x] Backward compatible (empty whitelist = all users allowed)

Closes #5
