### PR TITLE
feat: activate /ulw-loop for orchestrator sessions

### DIFF
--- a/src/prompts/orchestrator.ts
+++ b/src/prompts/orchestrator.ts
@@ -83,11 +83,8 @@ _I'll post progress updates as I work. If I need clarification, I'll ask here._"
 3. **Plan** - Create a clear implementation plan. For complex tasks, consult Oracle for architecture guidance.
 4. Post checkpoint comment with your plan.
 
-### Phase 2: Implementation (Use Ralph Loop)
-5. **Implement** - Use Ralph Loop for iterative development:
-   \`\`\`
-   /ralph-loop "Implement the planned changes. Test as you go. Don't stop until <promise>DONE</promise>."
-   \`\`\`
+### Phase 2: Implementation
+5. **Implement** - You are running inside an ULTRAWORK loop. Iterate until done:
    - Write clean, well-documented code following existing project conventions
    - Delegate to specialists when appropriate:
      - Frontend/UI work → @frontend-ui-ux-engineer
@@ -106,22 +103,16 @@ _I'll post progress updates as I work. If I need clarification, I'll ask here._"
      \\\`\\\`\\\`
 
 ### Phase 3: Testing (CRITICAL)
-6. **Test** - Run existing tests. If no tests exist, generate them:
-   \`\`\`
-   /ralph-loop "Run all tests. If tests fail, fix them. If no tests exist, generate comprehensive tests. End with <promise>DONE</promise> when all pass."
-   \`\`\`
+6. **Test** - Run existing tests. If no tests exist, generate them.
    - For web features, use Playwright for E2E testing
-   - Only proceed when ALL tests pass
+   - Keep iterating until ALL tests pass — do not proceed until green
 
 ### Phase 4: Quality Gates (REQUIRED)
 7. **Quality Gates** - Run and pass ALL quality gates:
    - Linting: \`npm run lint\` or equivalent
    - Type checking: \`tsc --noEmit\` or equivalent
    - Build: \`npm run build\` or equivalent
-   - If any fail, use Ralph Loop to fix:
-   \`\`\`
-   /ralph-loop "Fix all quality gate failures. Re-run until all pass."
-   \`\`\`
+   - If any fail, fix and re-run. Do not proceed until all pass.
 
 ### Phase 5: CI & PR
 8. **Push & Wait for CI** - Push your branch and wait for CI to pass
@@ -135,20 +126,6 @@ _I'll post progress updates as I work. If I need clarification, I'll ask here._"
     - Link to PR
     - Test results
     - Session share link for full transparency
-
-## Ralph Loop Integration
-
-You have access to Ralph Loop - use it strategically for:
-
-**Multi-Iteration Work:**
-- Complex implementations
-- Test-fix cycles
-- Quality gate enforcement
-
-**Parameters:**
-- Max iterations: ${config.testing.ralphLoopMaxIterations}
-- Completion signal: \`<promise>DONE</promise>\`
-- Auto-continue: true
 
 ## gh CLI Reference
 

--- a/src/tasks/opencode.ts
+++ b/src/tasks/opencode.ts
@@ -213,7 +213,7 @@ export class OpenCodeManager {
         try {
             await this.client.sendPromptAsync(session.id, [{
                 type: 'text',
-                text: prompt
+                text: `/ulw-loop ${prompt}`
             }]);
         } catch (error: any) {
             logger.error({
@@ -275,7 +275,7 @@ export class OpenCodeManager {
         try {
             await this.client.sendPromptAsync(previousSessionId, [{
                 type: 'text',
-                text: prompt
+                text: `/ulw-loop ${prompt}`
             }]);
         } catch (error: any) {
             logger.error({


### PR DESCRIPTION
## Summary

The orchestrator sends prompts to OpenCode but never actually activates the ULTRAWORK loop — the `/ralph-loop` references in the prompt template are decorative text, not command invocations.

## Changes

- **`src/tasks/opencode.ts`**: Prefix both `startTask` and `continueTask` prompt payloads with `/ulw-loop` so the loop command is actually invoked
- **`src/prompts/orchestrator.ts`**: Remove decorative `/ralph-loop` code blocks and the "Ralph Loop Integration" section — the loop is now activated at the transport layer, so the prompt just needs to describe *what* to do, not *how* to loop

## Before → After

**Before**: Agent receives a plain text prompt containing `/ralph-loop "..."` as example text — never executes it  
**After**: Agent receives `/ulw-loop <full prompt>` — the ULTRAWORK loop activates with Oracle verification on completion

Net: -30 lines of prompt noise, +2 lines of actual loop activation.